### PR TITLE
Address edge cases

### DIFF
--- a/contracts/infinity-pool/src/swap_processor.rs
+++ b/contracts/infinity-pool/src/swap_processor.rs
@@ -24,7 +24,7 @@ pub struct PoolPair {
 
 impl Ord for PoolPair {
     fn cmp(&self, other: &Self) -> Ordering {
-        self.quote_price.cmp(&other.quote_price)
+        (self.quote_price, self.pool.id).cmp(&(other.quote_price, other.pool.id))
     }
 }
 
@@ -36,7 +36,7 @@ impl PartialOrd for PoolPair {
 
 impl PartialEq for PoolPair {
     fn eq(&self, other: &Self) -> bool {
-        self.quote_price == other.quote_price
+        (self.quote_price, self.pool.id) == (other.quote_price, other.pool.id)
     }
 }
 


### PR DESCRIPTION
Addressed the edge cases below
- Handle the case where loading the next pool in a swap fails because no more valid pools exist
- I believe two PoolPairs with matching `quote_price` are deduped in BTreeSet when they should not be