### PR TITLE
Sim swap nfts for tokens ii

### DIFF
--- a/contracts/infinity-pool/src/query.rs
+++ b/contracts/infinity-pool/src/query.rs
@@ -361,7 +361,7 @@ pub fn sim_swap_tokens_for_specific_nfts(
     );
     processor
         .swap_tokens_for_specific_nfts(deps.storage, pool_nfts_to_swap_for, swap_params)
-        .map_err(|_| StdError::generic_err("swap_tokens_for_specific_nfts err"))?;
+        .map_err(|err| StdError::generic_err(err.to_string()))?;
 
     Ok(SwapResponse {
         swaps: processor.swaps,

--- a/contracts/infinity-pool/src/query.rs
+++ b/contracts/infinity-pool/src/query.rs
@@ -341,11 +341,18 @@ pub fn sim_swap_tokens_for_specific_nfts(
     let collection_royalties = load_collection_royalties(deps, &collection)
         .map_err(|_| StdError::generic_err("Collection not found"))?;
 
+    let mut spend_amount = 0_u128;
+    for pool in pool_nfts_to_swap_for.iter() {
+        for nft_swap in pool.nft_swaps.iter() {
+            spend_amount += nft_swap.token_amount.u128();
+        }
+    }
+
     let mut processor = SwapProcessor::new(
         TransactionType::Buy,
         collection,
         nft_recipient.clone(),
-        Uint128::zero(),
+        spend_amount.into(),
         nft_recipient,
         marketplace_params.params.trading_fee_percent,
         collection_royalties,

--- a/contracts/infinity-pool/src/query.rs
+++ b/contracts/infinity-pool/src/query.rs
@@ -296,7 +296,7 @@ pub fn sim_swap_nfts_for_tokens(
     );
     processor
         .swap_nfts_for_tokens(deps.storage, nfts_to_swap, swap_params)
-        .map_err(|_| StdError::generic_err("swap_nfts_for_tokens err"))?;
+        .map_err(|err| StdError::generic_err(err.to_string()))?;
 
     Ok(SwapResponse {
         swaps: processor.swaps,

--- a/contracts/infinity-pool/src/swap_processor.rs
+++ b/contracts/infinity-pool/src/swap_processor.rs
@@ -372,7 +372,6 @@ impl<'a> SwapProcessor<'a> {
         swap_params: SwapParams,
     ) -> Result<(), ContractError> {
         // Load the only pool that will be needed
-        println!("nfts to swap are {:?}", nfts_to_swap);
         let mut pool = pool;
         {
             for nft_swap in nfts_to_swap {
@@ -408,11 +407,9 @@ impl<'a> SwapProcessor<'a> {
         nfts_to_swap: Vec<NftSwap>,
         swap_params: SwapParams,
     ) -> Result<(), ContractError> {
-        println!("nfts to swap are {:?}", nfts_to_swap);
         for nft_swap in nfts_to_swap {
             // Load best priced pool
             let pool_pair_option = self.load_next_pool(storage)?;
-            println!("pool pair option is some{:?}", pool_pair_option.is_some());
 
             // No pools found, so return empty
             if pool_pair_option.is_none() {

--- a/contracts/infinity-pool/src/swap_processor.rs
+++ b/contracts/infinity-pool/src/swap_processor.rs
@@ -372,6 +372,7 @@ impl<'a> SwapProcessor<'a> {
         swap_params: SwapParams,
     ) -> Result<(), ContractError> {
         // Load the only pool that will be needed
+        println!("nfts to swap are {:?}", nfts_to_swap);
         let mut pool = pool;
         {
             for nft_swap in nfts_to_swap {
@@ -407,9 +408,12 @@ impl<'a> SwapProcessor<'a> {
         nfts_to_swap: Vec<NftSwap>,
         swap_params: SwapParams,
     ) -> Result<(), ContractError> {
+        println!("nfts to swap are {:?}", nfts_to_swap);
         for nft_swap in nfts_to_swap {
             // Load best priced pool
             let pool_pair_option = self.load_next_pool(storage)?;
+            println!("pool pair option is some{:?}", pool_pair_option.is_some());
+
             // No pools found, so return empty
             if pool_pair_option.is_none() {
                 return Ok(());

--- a/contracts/infinity-pool/src/swap_processor.rs
+++ b/contracts/infinity-pool/src/swap_processor.rs
@@ -410,7 +410,6 @@ impl<'a> SwapProcessor<'a> {
         for nft_swap in nfts_to_swap {
             // Load best priced pool
             let pool_pair_option = self.load_next_pool(storage)?;
-
             // No pools found, so return empty
             if pool_pair_option.is_none() {
                 return Ok(());

--- a/contracts/infinity-pool/src/swap_processor.rs
+++ b/contracts/infinity-pool/src/swap_processor.rs
@@ -461,7 +461,6 @@ impl<'a> SwapProcessor<'a> {
                 return Err(ContractError::InvalidPool("pool not found".to_string()));
             }
             let mut pool = pool_option.unwrap();
-            self.remaining_balance += pool.total_tokens;
             // Iterate for all NFTs selected for the given
             for nft_swap in pool_nfts.nft_swaps {
                 let result = self.process_swap(&mut pool, nft_swap, TransactionType::Buy);

--- a/contracts/infinity-pool/src/swap_processor.rs
+++ b/contracts/infinity-pool/src/swap_processor.rs
@@ -461,6 +461,7 @@ impl<'a> SwapProcessor<'a> {
                 return Err(ContractError::InvalidPool("pool not found".to_string()));
             }
             let mut pool = pool_option.unwrap();
+
             // Iterate for all NFTs selected for the given
             for nft_swap in pool_nfts.nft_swaps {
                 let result = self.process_swap(&mut pool, nft_swap, TransactionType::Buy);

--- a/contracts/infinity-pool/src/swap_processor.rs
+++ b/contracts/infinity-pool/src/swap_processor.rs
@@ -461,7 +461,7 @@ impl<'a> SwapProcessor<'a> {
                 return Err(ContractError::InvalidPool("pool not found".to_string()));
             }
             let mut pool = pool_option.unwrap();
-
+            self.remaining_balance += pool.total_tokens;
             // Iterate for all NFTs selected for the given
             for nft_swap in pool_nfts.nft_swaps {
                 let result = self.process_swap(&mut pool, nft_swap, TransactionType::Buy);

--- a/contracts/infinity-pool/src/testing/tests/sim_tests.rs
+++ b/contracts/infinity-pool/src/testing/tests/sim_tests.rs
@@ -1,3 +1,4 @@
 mod helpers;
 mod sim_direct_swap_nfts_for_tokens;
+mod sim_direct_swap_tokens_for_specific_nfts;
 mod sim_swap_nfts_for_tokens;

--- a/contracts/infinity-pool/src/testing/tests/sim_tests/helpers.rs
+++ b/contracts/infinity-pool/src/testing/tests/sim_tests/helpers.rs
@@ -171,7 +171,8 @@ pub fn deposit_nfts(
         collection: collection.to_string(),
         nft_token_ids: vec![token_id_1.to_string(), token_id_2.to_string()],
     };
-    let _ = router.execute_contract(creator, infinity_pool, &msg, &[]);
+    let res = router.execute_contract(creator, infinity_pool, &msg, &[]);
+    println!("response from deposit nfts is {:?}", res);
 
     DepositNftsResult {
         token_id_1,

--- a/contracts/infinity-pool/src/testing/tests/sim_tests/helpers.rs
+++ b/contracts/infinity-pool/src/testing/tests/sim_tests/helpers.rs
@@ -21,6 +21,7 @@ use test_suite::common_setup::setup_accounts_and_block::setup_block_time;
 
 const ASSET_ACCOUNT: &str = "asset";
 
+#[derive(Debug)]
 pub struct SwapPoolResult {
     pub user1: Addr,
     pub user2: Addr,
@@ -156,8 +157,7 @@ pub fn deposit_nfts(
         collection: collection.to_string(),
         nft_token_ids: vec![token_id_1.to_string(), token_id_2.to_string()],
     };
-    let res = router.execute_contract(creator, infinity_pool, &msg, &[]);
-    println!("res from deposit tokens is {:?}", res);
+    let _ = router.execute_contract(creator, infinity_pool, &msg, &[]);
 
     DepositNftsResult {
         token_id_1,

--- a/contracts/infinity-pool/src/testing/tests/sim_tests/helpers.rs
+++ b/contracts/infinity-pool/src/testing/tests/sim_tests/helpers.rs
@@ -247,12 +247,6 @@ pub fn get_sim_swap_nfts_for_tokens_msg(
     }
 }
 
-// pool_id: u64,
-// nfts_to_swap_for: Vec<NftSwap>,
-// swap_params: SwapParams,
-// nft_recipient: String,
-// finder: Option<String>,
-
 pub fn get_sim_direct_swap_tokens_for_specific_nfts_msg(
     pool: Pool,
     token_id_1: u32,

--- a/contracts/infinity-pool/src/testing/tests/sim_tests/helpers.rs
+++ b/contracts/infinity-pool/src/testing/tests/sim_tests/helpers.rs
@@ -257,7 +257,6 @@ pub fn check_nft_sale(
     user2: Addr,
     token_id: String,
 ) {
-    println!("full swaps is {:?}", swaps);
     assert_eq!(swaps[0].spot_price.u128(), expected_spot_price);
     let expected_nft_payment = Some(NftPayment {
         nft_token_id: token_id,

--- a/contracts/infinity-pool/src/testing/tests/sim_tests/sim_direct_swap_nfts_for_tokens.rs
+++ b/contracts/infinity-pool/src/testing/tests/sim_tests/sim_direct_swap_nfts_for_tokens.rs
@@ -446,7 +446,7 @@ fn robust_query_does_not_revert_whole_tx_on_error() {
 }
 
 #[test]
-fn network_fee_is_applied_correctly() {
+fn trading_fee_is_applied_correctly() {
     let spot_price = 20000_u128;
     let trading_fee = 500_u64;
     let vt = standard_minter_template(5000);

--- a/contracts/infinity-pool/src/testing/tests/sim_tests/sim_direct_swap_nfts_for_tokens.rs
+++ b/contracts/infinity-pool/src/testing/tests/sim_tests/sim_direct_swap_nfts_for_tokens.rs
@@ -201,7 +201,7 @@ fn invalid_nft_pool_can_not_deposit() {
 }
 
 #[test]
-fn not_enough_deposit_no_swap() {
+fn insufficient_tokens_error() {
     let spot_price = 1000_u128;
     let vt = standard_minter_template(5000);
     let mut router = vt.router;

--- a/contracts/infinity-pool/src/testing/tests/sim_tests/sim_direct_swap_tokens_for_specific_nfts.rs
+++ b/contracts/infinity-pool/src/testing/tests/sim_tests/sim_direct_swap_tokens_for_specific_nfts.rs
@@ -1,17 +1,19 @@
-use crate::msg::SwapResponse;
+use crate::msg::QueryMsg::SimDirectSwapTokensforSpecificNfts;
+use crate::msg::{NftSwap, SwapParams, SwapResponse};
 use crate::state::PoolType;
 use crate::testing::helpers::nft_functions::{approve, mint};
 use crate::testing::helpers::pool_functions::deposit_tokens;
-use crate::testing::setup::templates::standard_minter_template;
+use crate::testing::setup::templates::{_minter_template_30_pct_fee, standard_minter_template};
 use crate::testing::tests::sim_tests::helpers::{
     check_nft_sale, deposit_nfts, get_sim_direct_swap_tokens_for_specific_nfts_msg,
     set_pool_active, setup_swap_pool, NftSaleCheckParams, SwapPoolResult, SwapPoolSetup,
     VendingTemplateSetup, ASSET_ACCOUNT,
 };
-use cosmwasm_std::Addr;
 use cosmwasm_std::StdError::GenericErr;
 use cosmwasm_std::StdResult;
 use cosmwasm_std::Uint128;
+use cosmwasm_std::{Addr, Timestamp};
+use sg_std::GENESIS_MINT_START_TIME;
 use std::vec;
 
 #[test]
@@ -67,9 +69,7 @@ fn error_inactive_pool() {
         None,
     );
 
-    let res: StdResult<SwapResponse> = router
-        .wrap()
-        .query_wasm_smart(spr.infinity_pool.clone(), &swap_msg);
+    let res: StdResult<SwapResponse> = router.wrap().query_wasm_smart(spr.infinity_pool, &swap_msg);
 
     let error_msg = res.err().unwrap();
 
@@ -230,4 +230,480 @@ fn pool_type_must_be_pool_trade_or_nft_error() {
     };
     let error_msg = res.err().unwrap();
     assert_eq!(error_msg, expected_error);
+}
+
+#[test]
+fn insuficient_nfts_error() {
+    let spot_price = 1000_u128;
+    let vt = standard_minter_template(5000);
+    let mut router = vt.router;
+
+    let vts = VendingTemplateSetup {
+        router: &mut router,
+        minter: vt.collection_response_vec[0].minter.as_ref().unwrap(),
+        creator: vt.accts.creator,
+        user1: vt.accts.bidder,
+        user2: vt.accts.owner,
+        collection: vt.collection_response_vec[0].collection.as_ref().unwrap(),
+    };
+    let swap_pool_configs = vec![SwapPoolSetup {
+        pool_type: PoolType::Trade,
+        spot_price,
+        finders_fee_bps: None,
+    }];
+    let mut swap_results: Vec<Result<SwapPoolResult, anyhow::Error>> =
+        setup_swap_pool(vts, swap_pool_configs, None);
+
+    let spr: SwapPoolResult = swap_results.pop().unwrap().unwrap();
+
+    set_pool_active(
+        &mut router,
+        true,
+        spr.pool.clone(),
+        spr.creator.clone(),
+        spr.infinity_pool.clone(),
+    );
+
+    let token_id_1 = mint(&mut router, &spr.user1.clone(), &spr.minter);
+    approve(
+        &mut router,
+        &spr.user1.clone(),
+        &spr.collection.clone(),
+        &spr.infinity_pool.clone(),
+        token_id_1,
+    );
+
+    let sale_price = 2000_u128;
+    let swap_msg = get_sim_direct_swap_tokens_for_specific_nfts_msg(
+        spr.pool.clone(),
+        token_id_1,
+        sale_price,
+        false,
+        spr.user2.clone(),
+        None,
+    );
+
+    let res: StdResult<SwapResponse> = router
+        .wrap()
+        .query_wasm_smart(spr.infinity_pool.clone(), &swap_msg);
+    let expected_error = GenericErr {
+        msg: "Querier contract error: Generic error: Swap error: pool cannot offer quote"
+            .to_string(),
+    };
+    let error_msg = res.err().unwrap();
+    assert_eq!(error_msg, expected_error);
+}
+
+#[test]
+fn sale_price_above_expected_error() {
+    let spot_price = 1000_u128;
+    let vt = standard_minter_template(5000);
+    let mut router = vt.router;
+
+    let vts = VendingTemplateSetup {
+        router: &mut router,
+        minter: vt.collection_response_vec[0].minter.as_ref().unwrap(),
+        creator: vt.accts.creator,
+        user1: vt.accts.bidder,
+        user2: vt.accts.owner,
+        collection: vt.collection_response_vec[0].collection.as_ref().unwrap(),
+    };
+    let swap_pool_configs = vec![SwapPoolSetup {
+        pool_type: PoolType::Nft,
+        spot_price,
+        finders_fee_bps: None,
+    }];
+    let mut swap_results: Vec<Result<SwapPoolResult, anyhow::Error>> =
+        setup_swap_pool(vts, swap_pool_configs, None);
+
+    let spr: SwapPoolResult = swap_results.pop().unwrap().unwrap();
+
+    set_pool_active(
+        &mut router,
+        true,
+        spr.pool.clone(),
+        spr.creator.clone(),
+        spr.infinity_pool.clone(),
+    );
+
+    let token_id_1 = deposit_nfts(
+        &mut router,
+        spr.user1,
+        spr.minter,
+        spr.collection,
+        spr.infinity_pool.clone(),
+        spr.pool.clone(),
+        spr.creator.clone(),
+    )
+    .token_id_1;
+
+    let sale_price = 500_u128;
+    let swap_msg = get_sim_direct_swap_tokens_for_specific_nfts_msg(
+        spr.pool.clone(),
+        token_id_1,
+        sale_price,
+        false,
+        spr.user2.clone(),
+        None,
+    );
+
+    let res: StdResult<SwapResponse> = router.wrap().query_wasm_smart(spr.infinity_pool, &swap_msg);
+
+    let expected_error = GenericErr {
+            msg: "Querier contract error: Generic error: Swap error: pool sale price is above max expected" 
+                .to_string(),
+        };
+    let error_msg = res.err().unwrap();
+    assert_eq!(error_msg, expected_error);
+}
+
+#[test]
+fn robust_query_does_not_revert_whole_tx() {
+    let spot_price = 1000_u128;
+    let vt = standard_minter_template(5000);
+    let mut router = vt.router;
+
+    let vts = VendingTemplateSetup {
+        router: &mut router,
+        minter: vt.collection_response_vec[0].minter.as_ref().unwrap(),
+        creator: vt.accts.creator,
+        user1: vt.accts.bidder,
+        user2: vt.accts.owner,
+        collection: vt.collection_response_vec[0].collection.as_ref().unwrap(),
+    };
+    let swap_pool_configs = vec![SwapPoolSetup {
+        pool_type: PoolType::Nft,
+        spot_price,
+        finders_fee_bps: None,
+    }];
+    let mut swap_results: Vec<Result<SwapPoolResult, anyhow::Error>> =
+        setup_swap_pool(vts, swap_pool_configs, None);
+
+    let spr: SwapPoolResult = swap_results.pop().unwrap().unwrap();
+
+    set_pool_active(
+        &mut router,
+        true,
+        spr.pool.clone(),
+        spr.creator.clone(),
+        spr.infinity_pool.clone(),
+    );
+
+    let token_id_1 = deposit_nfts(
+        &mut router,
+        spr.user1,
+        spr.minter,
+        spr.collection,
+        spr.infinity_pool.clone(),
+        spr.pool.clone(),
+        spr.creator.clone(),
+    )
+    .token_id_1;
+
+    let swap_msg = SimDirectSwapTokensforSpecificNfts {
+        pool_id: spr.pool.id,
+        nfts_to_swap_for: vec![
+            NftSwap {
+                nft_token_id: token_id_1.to_string(),
+                token_amount: Uint128::new(1200),
+            },
+            NftSwap {
+                nft_token_id: token_id_1.to_string(),
+                token_amount: Uint128::new(500),
+            },
+        ],
+        swap_params: SwapParams {
+            deadline: Timestamp::from_nanos(GENESIS_MINT_START_TIME).plus_seconds(1000),
+            robust: true,
+        },
+        nft_recipient: spr.user2.to_string(),
+        finder: None,
+    };
+
+    let res: StdResult<SwapResponse> = router
+        .wrap()
+        .query_wasm_smart(spr.infinity_pool.clone(), &swap_msg);
+    assert!(res.is_ok());
+    let swaps = res.unwrap().swaps;
+
+    let swap_price_plus_delta = spot_price;
+    let expected_royalty_fee = Uint128::from(swap_price_plus_delta)
+        .checked_multiply_ratio(10_u128, 100_u128)
+        .unwrap()
+        .u128();
+    let expected_network_fee = Uint128::from(spot_price)
+        .checked_multiply_ratio(2_u128, 100_u128)
+        .unwrap()
+        .u128();
+
+    let nft_sale_check_params = NftSaleCheckParams {
+        expected_spot_price: spot_price,
+        expected_royalty_price: expected_royalty_fee,
+        expected_network_fee,
+        expected_finders_fee: 0,
+        swaps,
+        creator: spr.creator,
+        expected_seller: Addr::unchecked(ASSET_ACCOUNT),
+        token_id: token_id_1.to_string(),
+        expected_nft_payer: Addr::unchecked(spr.user2.clone()),
+        expected_finder: spr.user2,
+    };
+    check_nft_sale(nft_sale_check_params);
+}
+
+#[test]
+fn trading_fee_is_applied_correctly() {
+    let spot_price = 1000_u128;
+    let trading_fee = 500_u64;
+    let vt = standard_minter_template(5000);
+    let mut router = vt.router;
+
+    let vts = VendingTemplateSetup {
+        router: &mut router,
+        minter: vt.collection_response_vec[0].minter.as_ref().unwrap(),
+        creator: vt.accts.creator,
+        user1: vt.accts.bidder,
+        user2: vt.accts.owner,
+        collection: vt.collection_response_vec[0].collection.as_ref().unwrap(),
+    };
+    let swap_pool_configs = vec![SwapPoolSetup {
+        pool_type: PoolType::Nft,
+        spot_price,
+        finders_fee_bps: None,
+    }];
+    let mut swap_results: Vec<Result<SwapPoolResult, anyhow::Error>> =
+        setup_swap_pool(vts, swap_pool_configs, Some(trading_fee));
+
+    let spr: SwapPoolResult = swap_results.pop().unwrap().unwrap();
+
+    set_pool_active(
+        &mut router,
+        true,
+        spr.pool.clone(),
+        spr.creator.clone(),
+        spr.infinity_pool.clone(),
+    );
+
+    let token_id_1 = deposit_nfts(
+        &mut router,
+        spr.user1,
+        spr.minter,
+        spr.collection,
+        spr.infinity_pool.clone(),
+        spr.pool.clone(),
+        spr.creator.clone(),
+    )
+    .token_id_1;
+
+    let sale_price = 2000_u128;
+    let swap_msg = get_sim_direct_swap_tokens_for_specific_nfts_msg(
+        spr.pool.clone(),
+        token_id_1,
+        sale_price,
+        true,
+        spr.user2.clone(),
+        None,
+    );
+
+    let res: StdResult<SwapResponse> = router
+        .wrap()
+        .query_wasm_smart(spr.infinity_pool.clone(), &swap_msg);
+    assert!(res.is_ok());
+    let swaps = res.unwrap().swaps;
+
+    let swap_price_plus_delta = spot_price;
+    let expected_royalty_fee = Uint128::from(swap_price_plus_delta)
+        .checked_multiply_ratio(10_u128, 100_u128)
+        .unwrap()
+        .u128();
+    let expected_network_fee = Uint128::from(spot_price)
+        .checked_multiply_ratio(5_u128, 100_u128)
+        .unwrap()
+        .u128();
+
+    let nft_sale_check_params = NftSaleCheckParams {
+        expected_spot_price: spot_price,
+        expected_royalty_price: expected_royalty_fee,
+        expected_network_fee,
+        expected_finders_fee: 0,
+        swaps,
+        creator: spr.creator,
+        expected_seller: Addr::unchecked(ASSET_ACCOUNT),
+        token_id: token_id_1.to_string(),
+        expected_nft_payer: Addr::unchecked(spr.user2.clone()),
+        expected_finder: spr.user2,
+    };
+    check_nft_sale(nft_sale_check_params);
+}
+
+#[test]
+fn royalty_fee_applied_correctly() {
+    let spot_price = 1000_u128;
+    let trading_fee = 500_u64;
+    let vt = _minter_template_30_pct_fee(5000);
+    let mut router = vt.router;
+
+    let vts = VendingTemplateSetup {
+        router: &mut router,
+        minter: vt.collection_response_vec[0].minter.as_ref().unwrap(),
+        creator: vt.accts.creator,
+        user1: vt.accts.bidder,
+        user2: vt.accts.owner,
+        collection: vt.collection_response_vec[0].collection.as_ref().unwrap(),
+    };
+    let swap_pool_configs = vec![SwapPoolSetup {
+        pool_type: PoolType::Nft,
+        spot_price,
+        finders_fee_bps: None,
+    }];
+    let mut swap_results: Vec<Result<SwapPoolResult, anyhow::Error>> =
+        setup_swap_pool(vts, swap_pool_configs, Some(trading_fee));
+
+    let spr: SwapPoolResult = swap_results.pop().unwrap().unwrap();
+
+    set_pool_active(
+        &mut router,
+        true,
+        spr.pool.clone(),
+        spr.creator.clone(),
+        spr.infinity_pool.clone(),
+    );
+
+    let token_id_1 = deposit_nfts(
+        &mut router,
+        spr.user1,
+        spr.minter,
+        spr.collection,
+        spr.infinity_pool.clone(),
+        spr.pool.clone(),
+        spr.creator.clone(),
+    )
+    .token_id_1;
+
+    let sale_price = 2000_u128;
+    let swap_msg = get_sim_direct_swap_tokens_for_specific_nfts_msg(
+        spr.pool.clone(),
+        token_id_1,
+        sale_price,
+        true,
+        spr.user2.clone(),
+        None,
+    );
+
+    let res: StdResult<SwapResponse> = router
+        .wrap()
+        .query_wasm_smart(spr.infinity_pool.clone(), &swap_msg);
+    assert!(res.is_ok());
+    let swaps = res.unwrap().swaps;
+
+    let swap_price_plus_delta = spot_price;
+    let expected_royalty_fee = Uint128::from(swap_price_plus_delta)
+        .checked_multiply_ratio(30_u128, 100_u128)
+        .unwrap()
+        .u128();
+    let expected_network_fee = Uint128::from(spot_price)
+        .checked_multiply_ratio(5_u128, 100_u128)
+        .unwrap()
+        .u128();
+
+    let nft_sale_check_params = NftSaleCheckParams {
+        expected_spot_price: spot_price,
+        expected_royalty_price: expected_royalty_fee,
+        expected_network_fee,
+        expected_finders_fee: 0,
+        swaps,
+        creator: spr.creator,
+        expected_seller: Addr::unchecked(ASSET_ACCOUNT),
+        token_id: token_id_1.to_string(),
+        expected_nft_payer: Addr::unchecked(spr.user2.clone()),
+        expected_finder: spr.user2,
+    };
+    check_nft_sale(nft_sale_check_params);
+}
+
+#[test]
+fn finders_fee_is_applied_correctly() {
+    let finders_fee_bps = 2_u128;
+    let spot_price = 1000_u128;
+    let vt = standard_minter_template(5000);
+    let mut router = vt.router;
+
+    let vts = VendingTemplateSetup {
+        router: &mut router,
+        minter: vt.collection_response_vec[0].minter.as_ref().unwrap(),
+        creator: vt.accts.creator,
+        user1: vt.accts.bidder,
+        user2: vt.accts.owner,
+        collection: vt.collection_response_vec[0].collection.as_ref().unwrap(),
+    };
+    let swap_pool_configs = vec![SwapPoolSetup {
+        pool_type: PoolType::Nft,
+        spot_price,
+        finders_fee_bps: Some(finders_fee_bps.try_into().unwrap()),
+    }];
+    let mut swap_results: Vec<Result<SwapPoolResult, anyhow::Error>> =
+        setup_swap_pool(vts, swap_pool_configs, None);
+
+    let spr: SwapPoolResult = swap_results.pop().unwrap().unwrap();
+
+    set_pool_active(
+        &mut router,
+        true,
+        spr.pool.clone(),
+        spr.creator.clone(),
+        spr.infinity_pool.clone(),
+    );
+
+    let token_id_1 = deposit_nfts(
+        &mut router,
+        spr.user1,
+        spr.minter,
+        spr.collection,
+        spr.infinity_pool.clone(),
+        spr.pool.clone(),
+        spr.creator.clone(),
+    )
+    .token_id_1;
+
+    let sale_price = 1000_u128;
+    let swap_msg = get_sim_direct_swap_tokens_for_specific_nfts_msg(
+        spr.pool.clone(),
+        token_id_1,
+        sale_price,
+        true,
+        spr.user2.clone(),
+        Some(spr.user2.to_string()),
+    );
+
+    let res: StdResult<SwapResponse> = router
+        .wrap()
+        .query_wasm_smart(spr.infinity_pool.clone(), &swap_msg);
+    assert!(res.is_ok());
+    let swaps = res.unwrap().swaps;
+
+    let expected_royalty_fee = Uint128::from(spot_price)
+        .checked_multiply_ratio(10_u128, 100_u128)
+        .unwrap()
+        .u128();
+    let expected_network_fee = Uint128::from(spot_price)
+        .checked_multiply_ratio(2_u128, 100_u128)
+        .unwrap()
+        .u128();
+    let expected_finders_fee = Uint128::from(spot_price)
+        .checked_multiply_ratio(finders_fee_bps, Uint128::new(100).u128())
+        .unwrap();
+
+    let nft_sale_check_params = NftSaleCheckParams {
+        expected_spot_price: spot_price,
+        expected_royalty_price: expected_royalty_fee,
+        expected_network_fee,
+        expected_finders_fee: expected_finders_fee.u128(),
+        swaps,
+        creator: spr.creator,
+        expected_seller: Addr::unchecked(ASSET_ACCOUNT),
+        token_id: token_id_1.to_string(),
+        expected_nft_payer: Addr::unchecked(spr.user2.clone()),
+        expected_finder: spr.user2,
+    };
+    check_nft_sale(nft_sale_check_params);
 }

--- a/contracts/infinity-pool/src/testing/tests/sim_tests/sim_direct_swap_tokens_for_specific_nfts.rs
+++ b/contracts/infinity-pool/src/testing/tests/sim_tests/sim_direct_swap_tokens_for_specific_nfts.rs
@@ -1,0 +1,96 @@
+use crate::msg::SwapResponse;
+use crate::state::PoolType;
+use crate::testing::setup::templates::standard_minter_template;
+use crate::testing::tests::sim_tests::helpers::{
+    check_nft_sale, deposit_nfts, get_sim_direct_swap_tokens_for_specific_nfts_msg,
+    set_pool_active, setup_swap_pool, NftSaleCheckParams, SwapPoolResult, SwapPoolSetup,
+    VendingTemplateSetup, ASSET_ACCOUNT,
+};
+use cosmwasm_std::Addr;
+use cosmwasm_std::StdResult;
+use cosmwasm_std::Uint128;
+use std::vec;
+
+#[test]
+fn can_swap_active_pool() {
+    let spot_price = 1000_u128;
+    let vt = standard_minter_template(5000);
+    let mut router = vt.router;
+
+    let vts = VendingTemplateSetup {
+        router: &mut router,
+        minter: vt.collection_response_vec[0].minter.as_ref().unwrap(),
+        creator: vt.accts.creator,
+        user1: vt.accts.bidder,
+        user2: vt.accts.owner,
+        collection: vt.collection_response_vec[0].collection.as_ref().unwrap(),
+    };
+    let swap_pool_configs = vec![SwapPoolSetup {
+        pool_type: PoolType::Nft,
+        spot_price,
+        finders_fee_bps: None,
+    }];
+    let mut swap_results: Vec<Result<SwapPoolResult, anyhow::Error>> =
+        setup_swap_pool(vts, swap_pool_configs, None);
+
+    let spr: SwapPoolResult = swap_results.pop().unwrap().unwrap();
+
+    set_pool_active(
+        &mut router,
+        true,
+        spr.pool.clone(),
+        spr.creator.clone(),
+        spr.infinity_pool.clone(),
+    );
+
+    let token_id_1 = deposit_nfts(
+        &mut router,
+        spr.user1,
+        spr.minter,
+        spr.collection,
+        spr.infinity_pool.clone(),
+        spr.pool.clone(),
+        spr.creator.clone(),
+    )
+    .token_id_1;
+
+    let sale_price = 2000_u128;
+    let swap_msg = get_sim_direct_swap_tokens_for_specific_nfts_msg(
+        spr.pool.clone(),
+        token_id_1,
+        sale_price,
+        true,
+        spr.user2.clone(),
+        None,
+    );
+
+    let res: StdResult<SwapResponse> = router
+        .wrap()
+        .query_wasm_smart(spr.infinity_pool.clone(), &swap_msg);
+    assert!(res.is_ok());
+    let swaps = res.unwrap().swaps;
+
+    let swap_price_plus_delta = spot_price;
+    let expected_royalty_fee = Uint128::from(swap_price_plus_delta)
+        .checked_multiply_ratio(10_u128, 100_u128)
+        .unwrap()
+        .u128();
+    let expected_network_fee = Uint128::from(spot_price)
+        .checked_multiply_ratio(2_u128, 100_u128)
+        .unwrap()
+        .u128();
+
+    let nft_sale_check_params = NftSaleCheckParams {
+        expected_spot_price: spot_price,
+        expected_royalty_price: expected_royalty_fee,
+        expected_network_fee,
+        expected_finders_fee: 0,
+        swaps,
+        creator: spr.creator,
+        expected_seller: Addr::unchecked(ASSET_ACCOUNT),
+        token_id: token_id_1.to_string(),
+        expected_nft_payer: Addr::unchecked(spr.user2.clone()),
+        expected_finder: spr.user2,
+    };
+    check_nft_sale(nft_sale_check_params);
+}

--- a/contracts/infinity-pool/src/testing/tests/sim_tests/sim_swap_nfts_for_tokens.rs
+++ b/contracts/infinity-pool/src/testing/tests/sim_tests/sim_swap_nfts_for_tokens.rs
@@ -6,9 +6,108 @@ use crate::testing::tests::sim_tests::helpers::{
     check_nft_sale, deposit_nfts, deposit_tokens, get_sim_swap_nfts_for_tokens_msg,
     set_pool_active, setup_swap_pool, SwapPoolResult, SwapPoolSetup, VendingTemplateSetup,
 };
+use cosmwasm_std::Addr;
+use cosmwasm_std::StdError::GenericErr;
 use cosmwasm_std::StdResult;
 use cosmwasm_std::Uint128;
 use std::vec;
+
+#[test]
+fn cant_swap_two_inactive_pools() {
+    let spot_price_1 = 1000_u128;
+    let spot_price_2 = 1200_u128;
+    let vt = standard_minter_template(5000);
+
+    let mut router = vt.router;
+    let collection = vt.collection_response_vec[0].collection.as_ref().unwrap();
+    let user2 = setup_second_bidder_account(&mut router).unwrap();
+    let creator = vt.accts.creator;
+
+    let vts = VendingTemplateSetup {
+        router: &mut router,
+        minter: vt.collection_response_vec[0].minter.as_ref().unwrap(),
+        creator: creator.clone(),
+        user1: vt.accts.bidder,
+        user2: user2.clone(),
+        collection: &collection.clone(),
+    };
+    let swap_pool_configs = vec![
+        SwapPoolSetup {
+            pool_type: PoolType::Trade,
+            spot_price: spot_price_1,
+            finders_fee_bps: None,
+        },
+        SwapPoolSetup {
+            pool_type: PoolType::Trade,
+            spot_price: spot_price_2,
+            finders_fee_bps: None,
+        },
+    ];
+    let swap_results: Vec<Result<SwapPoolResult, anyhow::Error>> =
+        setup_swap_pool(vts, swap_pool_configs, None);
+
+    let sprs: Vec<Result<SwapPoolResult, anyhow::Error>> = swap_results;
+    let infinity_pool = &sprs[1].as_ref().unwrap().infinity_pool.clone();
+    let mut token_id_1 = 0;
+
+    for spr in sprs {
+        let spr = spr.unwrap();
+        set_pool_active(
+            &mut router,
+            false,
+            spr.pool.clone(),
+            creator.clone(),
+            infinity_pool.clone(),
+        );
+
+        token_id_1 = deposit_nfts(
+            &mut router,
+            spr.user1.clone(),
+            spr.minter.clone(),
+            spr.collection.clone(),
+            spr.infinity_pool.clone(),
+            spr.pool.clone(),
+            spr.creator.clone(),
+        )
+        .token_id_1;
+
+        let _ = deposit_tokens(
+            &mut router,
+            20500_u128,
+            spr.infinity_pool.clone(),
+            spr.pool.clone(),
+            spr.creator.clone(),
+        );
+    }
+    let sale_price = 1000_u128;
+    let swap_msg =
+        get_sim_swap_nfts_for_tokens_msg(collection, token_id_1, sale_price, false, user2, None);
+    let query_msg = QueryMsg::PoolQuotesSell {
+        collection: collection.to_string(),
+        query_options: QueryOptions {
+            /// Whether to sort items in ascending or descending order
+            descending: None,
+            /// The key to start the query after
+            start_after: None,
+            // The number of items that will be returned
+            limit: Some(5),
+        },
+    };
+    let res: StdResult<PoolQuoteResponse> =
+        router.wrap().query_wasm_smart(infinity_pool, &query_msg);
+    let expected_pool_quotes = PoolQuoteResponse {
+        pool_quotes: vec![],
+    };
+    assert_eq!(res.unwrap(), expected_pool_quotes);
+
+    let res: StdResult<SwapResponse> = router
+        .wrap()
+        .query_wasm_smart(infinity_pool.clone(), &swap_msg);
+    println!("res is {:?}", res);
+    assert!(res.is_ok());
+    let swaps = res.unwrap().swaps;
+    assert_eq!(swaps, []);
+}
 
 #[test]
 fn can_swap_two_active_pools() {
@@ -137,4 +236,278 @@ fn can_swap_two_active_pools() {
         user2,
         token_id_1.to_string(),
     )
+}
+
+#[test]
+fn pool_type_can_not_be_nft_error() {
+    let spot_price_1 = 1000_u128;
+    let spot_price_2 = 1200_u128;
+    let vt = standard_minter_template(5000);
+
+    let mut router = vt.router;
+    let collection = vt.collection_response_vec[0].collection.as_ref().unwrap();
+    let user2 = setup_second_bidder_account(&mut router).unwrap();
+    let creator = vt.accts.creator;
+
+    let vts = VendingTemplateSetup {
+        router: &mut router,
+        minter: vt.collection_response_vec[0].minter.as_ref().unwrap(),
+        creator: creator.clone(),
+        user1: vt.accts.bidder,
+        user2: user2.clone(),
+        collection: &collection.clone(),
+    };
+    let swap_pool_configs = vec![
+        SwapPoolSetup {
+            pool_type: PoolType::Nft,
+            spot_price: spot_price_1,
+            finders_fee_bps: None,
+        },
+        SwapPoolSetup {
+            pool_type: PoolType::Nft,
+            spot_price: spot_price_2,
+            finders_fee_bps: None,
+        },
+    ];
+    let swap_results: Vec<Result<SwapPoolResult, anyhow::Error>> =
+        setup_swap_pool(vts, swap_pool_configs, None);
+
+    let sprs: Vec<Result<SwapPoolResult, anyhow::Error>> = swap_results;
+    let infinity_pool = &sprs[1].as_ref().unwrap().infinity_pool.clone();
+    let mut token_id_1 = 0;
+
+    for spr in sprs {
+        let spr = spr.unwrap();
+        set_pool_active(
+            &mut router,
+            true,
+            spr.pool.clone(),
+            creator.clone(),
+            infinity_pool.clone(),
+        );
+
+        token_id_1 = deposit_nfts(
+            &mut router,
+            spr.user1.clone(),
+            spr.minter.clone(),
+            spr.collection.clone(),
+            spr.infinity_pool.clone(),
+            spr.pool.clone(),
+            spr.creator.clone(),
+        )
+        .token_id_1;
+
+        let _ = deposit_tokens(
+            &mut router,
+            20500_u128,
+            spr.infinity_pool.clone(),
+            spr.pool.clone(),
+            spr.creator.clone(),
+        );
+    }
+    let sale_price = 1000_u128;
+    let swap_msg =
+        get_sim_swap_nfts_for_tokens_msg(collection, token_id_1, sale_price, false, user2, None);
+
+    let res: StdResult<SwapResponse> = router
+        .wrap()
+        .query_wasm_smart(infinity_pool.clone(), &swap_msg);
+    assert_eq!(
+        res,
+        Err(GenericErr {
+            msg: "Querier contract error: Generic error: Invalid pool: pool does not buy NFTs"
+                .to_string()
+        })
+    );
+}
+
+#[test]
+fn insufficient_tokens_error() {
+    let spot_price_1 = 1000_u128;
+    let spot_price_2 = 1200_u128;
+    let vt = standard_minter_template(5000);
+
+    let mut router = vt.router;
+    let collection = vt.collection_response_vec[0].collection.as_ref().unwrap();
+    let user2 = setup_second_bidder_account(&mut router).unwrap();
+    let creator = vt.accts.creator;
+
+    let vts = VendingTemplateSetup {
+        router: &mut router,
+        minter: vt.collection_response_vec[0].minter.as_ref().unwrap(),
+        creator: creator.clone(),
+        user1: vt.accts.bidder,
+        user2: user2.clone(),
+        collection: &collection.clone(),
+    };
+    let swap_pool_configs = vec![
+        SwapPoolSetup {
+            pool_type: PoolType::Trade,
+            spot_price: spot_price_1,
+            finders_fee_bps: None,
+        },
+        SwapPoolSetup {
+            pool_type: PoolType::Trade,
+            spot_price: spot_price_2,
+            finders_fee_bps: None,
+        },
+    ];
+    let swap_results: Vec<Result<SwapPoolResult, anyhow::Error>> =
+        setup_swap_pool(vts, swap_pool_configs, None);
+
+    let sprs: Vec<Result<SwapPoolResult, anyhow::Error>> = swap_results;
+    let infinity_pool = &sprs[1].as_ref().unwrap().infinity_pool.clone();
+    let mut token_id_1 = 0;
+
+    for spr in sprs {
+        let spr = spr.unwrap();
+        set_pool_active(
+            &mut router,
+            true,
+            spr.pool.clone(),
+            creator.clone(),
+            infinity_pool.clone(),
+        );
+
+        token_id_1 = deposit_nfts(
+            &mut router,
+            spr.user1.clone(),
+            spr.minter.clone(),
+            spr.collection.clone(),
+            spr.infinity_pool.clone(),
+            spr.pool.clone(),
+            spr.creator.clone(),
+        )
+        .token_id_1;
+
+        let _ = deposit_tokens(
+            &mut router,
+            500_u128,
+            spr.infinity_pool.clone(),
+            spr.pool.clone(),
+            spr.creator.clone(),
+        );
+    }
+    let sale_price = 1000_u128;
+    let swap_msg =
+        get_sim_swap_nfts_for_tokens_msg(collection, token_id_1, sale_price, false, user2, None);
+
+    let res: StdResult<SwapResponse> = router
+        .wrap()
+        .query_wasm_smart(infinity_pool.clone(), &swap_msg);
+    assert_eq!(
+        res,
+        Err(GenericErr {
+            msg: "Querier contract error: Generic error: Swap error: pool cannot offer quote"
+                .to_string(),
+        })
+    );
+}
+
+#[test]
+fn invalid_sale_price_below_min_expected() {
+    let spot_price_1 = 1000_u128;
+    let spot_price_2 = 1200_u128;
+    let vt = standard_minter_template(5000);
+
+    let mut router = vt.router;
+    let collection = vt.collection_response_vec[0].collection.as_ref().unwrap();
+    let user2 = setup_second_bidder_account(&mut router).unwrap();
+    let creator = vt.accts.creator;
+
+    let vts = VendingTemplateSetup {
+        router: &mut router,
+        minter: vt.collection_response_vec[0].minter.as_ref().unwrap(),
+        creator: creator.clone(),
+        user1: vt.accts.bidder,
+        user2: user2.clone(),
+        collection: &collection.clone(),
+    };
+    let swap_pool_configs = vec![
+        SwapPoolSetup {
+            pool_type: PoolType::Trade,
+            spot_price: spot_price_1,
+            finders_fee_bps: None,
+        },
+        SwapPoolSetup {
+            pool_type: PoolType::Trade,
+            spot_price: spot_price_2,
+            finders_fee_bps: None,
+        },
+    ];
+    let swap_results: Vec<Result<SwapPoolResult, anyhow::Error>> =
+        setup_swap_pool(vts, swap_pool_configs, None);
+
+    let sprs: Vec<Result<SwapPoolResult, anyhow::Error>> = swap_results;
+    let infinity_pool = &sprs[1].as_ref().unwrap().infinity_pool.clone();
+    let mut token_id_1 = 0;
+
+    for spr in sprs {
+        let spr = spr.unwrap();
+        set_pool_active(
+            &mut router,
+            true,
+            spr.pool.clone(),
+            creator.clone(),
+            infinity_pool.clone(),
+        );
+
+        token_id_1 = deposit_nfts(
+            &mut router,
+            spr.user1.clone(),
+            spr.minter.clone(),
+            spr.collection.clone(),
+            spr.infinity_pool.clone(),
+            spr.pool.clone(),
+            spr.creator.clone(),
+        )
+        .token_id_1;
+
+        let _ = deposit_tokens(
+            &mut router,
+            20500_u128,
+            spr.infinity_pool.clone(),
+            spr.pool.clone(),
+            spr.creator.clone(),
+        );
+    }
+    let sale_price = 2000_u128;
+
+    let query_msg = QueryMsg::PoolQuotesSell {
+        collection: collection.to_string(),
+        query_options: QueryOptions {
+            /// Whether to sort items in ascending or descending order
+            descending: None,
+            /// The key to start the query after
+            start_after: None,
+            // The number of items that will be returned
+            limit: Some(5),
+        },
+    };
+    let res: StdResult<PoolQuoteResponse> =
+        router.wrap().query_wasm_smart(infinity_pool, &query_msg);
+
+    let expected_pool_quotes = PoolQuoteResponse {
+        pool_quotes: vec![
+            PoolQuote {
+                id: 2,
+                collection: Addr::unchecked(collection.to_string()),
+                quote_price: Uint128::new(spot_price_2),
+            },
+            PoolQuote {
+                id: 1,
+                collection: Addr::unchecked(collection.to_string()),
+                quote_price: Uint128::new(spot_price_1),
+            },
+        ],
+    };
+    assert_eq!(res.unwrap(), expected_pool_quotes);
+
+    let swap_msg =
+        get_sim_swap_nfts_for_tokens_msg(collection, token_id_1, sale_price, true, user2, None);
+    let res: StdResult<SwapResponse> = router
+        .wrap()
+        .query_wasm_smart(infinity_pool.clone(), &swap_msg);
+
+    assert_eq!(res.unwrap().swaps, []);
 }

--- a/contracts/infinity-pool/src/testing/tests/sim_tests/sim_swap_nfts_for_tokens.rs
+++ b/contracts/infinity-pool/src/testing/tests/sim_tests/sim_swap_nfts_for_tokens.rs
@@ -1,15 +1,17 @@
-use crate::msg::{PoolQuoteResponse, QueryMsg, QueryOptions, SwapResponse};
+use crate::msg::{NftSwap, PoolQuoteResponse, QueryMsg, QueryOptions, SwapParams, SwapResponse};
 use crate::state::{PoolQuote, PoolType};
 use crate::testing::setup::setup_accounts::setup_second_bidder_account;
-use crate::testing::setup::templates::standard_minter_template;
+use crate::testing::setup::templates::{_minter_template_30_pct_fee, standard_minter_template};
 use crate::testing::tests::sim_tests::helpers::{
     check_nft_sale, deposit_nfts, deposit_tokens, get_sim_swap_nfts_for_tokens_msg,
     set_pool_active, setup_swap_pool, SwapPoolResult, SwapPoolSetup, VendingTemplateSetup,
 };
-use cosmwasm_std::Addr;
+use crate::testing::tests::sim_tests::sim_swap_nfts_for_tokens::QueryMsg::SimSwapNftsForTokens;
 use cosmwasm_std::StdError::GenericErr;
 use cosmwasm_std::StdResult;
 use cosmwasm_std::Uint128;
+use cosmwasm_std::{Addr, Timestamp};
+use sg_std::GENESIS_MINT_START_TIME;
 use std::vec;
 
 #[test]
@@ -103,7 +105,6 @@ fn cant_swap_two_inactive_pools() {
     let res: StdResult<SwapResponse> = router
         .wrap()
         .query_wasm_smart(infinity_pool.clone(), &swap_msg);
-    println!("res is {:?}", res);
     assert!(res.is_ok());
     let swaps = res.unwrap().swaps;
     assert_eq!(swaps, []);
@@ -220,15 +221,19 @@ fn can_swap_two_active_pools() {
     assert!(res.is_ok());
     let swaps = res.unwrap().swaps;
     let highest_seller_price = spot_price_2 + Uint128::from(100u64).u128();
-    let expected_royalty_price = 130_u128;
-    let expected_network_fee = Uint128::from(highest_seller_price)
+    let spot_price_plus_delta = spot_price_2 + 100_u128;
+    let expected_royalty_fee = Uint128::from(spot_price_plus_delta)
+        .checked_multiply_ratio(10_u128, 100_u128)
+        .unwrap()
+        .u128();
+    let expected_network_fee = Uint128::from(spot_price_plus_delta)
         .checked_multiply_ratio(2_u128, 100_u128)
         .unwrap()
         .u128();
 
     check_nft_sale(
         highest_seller_price,
-        expected_royalty_price,
+        expected_royalty_fee,
         expected_network_fee,
         0,
         swaps,
@@ -510,4 +515,522 @@ fn invalid_sale_price_below_min_expected() {
         .query_wasm_smart(infinity_pool.clone(), &swap_msg);
 
     assert_eq!(res.unwrap().swaps, []);
+}
+
+#[test]
+fn robust_query_does_not_revert_whole_tx_on_error() {
+    let spot_price_1 = 1000_u128;
+    let spot_price_2 = 1200_u128;
+    let vt = standard_minter_template(5000);
+
+    let mut router = vt.router;
+    let collection = vt.collection_response_vec[0].collection.as_ref().unwrap();
+    let user2 = setup_second_bidder_account(&mut router).unwrap();
+    let creator = vt.accts.creator;
+
+    let vts = VendingTemplateSetup {
+        router: &mut router,
+        minter: vt.collection_response_vec[0].minter.as_ref().unwrap(),
+        creator: creator.clone(),
+        user1: vt.accts.bidder,
+        user2: user2.clone(),
+        collection: &collection.clone(),
+    };
+    let swap_pool_configs = vec![
+        SwapPoolSetup {
+            pool_type: PoolType::Trade,
+            spot_price: spot_price_1,
+            finders_fee_bps: None,
+        },
+        SwapPoolSetup {
+            pool_type: PoolType::Trade,
+            spot_price: spot_price_2,
+            finders_fee_bps: None,
+        },
+    ];
+    let swap_results: Vec<Result<SwapPoolResult, anyhow::Error>> =
+        setup_swap_pool(vts, swap_pool_configs, None);
+
+    let sprs: Vec<Result<SwapPoolResult, anyhow::Error>> = swap_results;
+    let infinity_pool = &sprs[1].as_ref().unwrap().infinity_pool.clone();
+    let (mut token_id_1, mut token_id_2) = (0, 0);
+
+    for spr in sprs {
+        let spr = spr.unwrap();
+        set_pool_active(
+            &mut router,
+            true,
+            spr.pool.clone(),
+            creator.clone(),
+            infinity_pool.clone(),
+        );
+
+        let tokens = deposit_nfts(
+            &mut router,
+            spr.user1.clone(),
+            spr.minter.clone(),
+            spr.collection.clone(),
+            spr.infinity_pool.clone(),
+            spr.pool.clone(),
+            spr.creator.clone(),
+        );
+        token_id_1 = tokens.token_id_1;
+        token_id_2 = tokens.token_id_2;
+
+        let _ = deposit_tokens(
+            &mut router,
+            20500_u128,
+            spr.infinity_pool.clone(),
+            spr.pool.clone(),
+            spr.creator.clone(),
+        );
+    }
+
+    let swap_msg = SimSwapNftsForTokens {
+        nfts_to_swap: vec![
+            NftSwap {
+                nft_token_id: token_id_2.to_string(),
+                token_amount: Uint128::new(spot_price_2),
+            },
+            NftSwap {
+                nft_token_id: token_id_1.to_string(),
+                token_amount: Uint128::new(20000_u128), // won't swap bc price too high
+            },
+        ],
+        swap_params: SwapParams {
+            deadline: Timestamp::from_nanos(GENESIS_MINT_START_TIME).plus_seconds(1000),
+            robust: true,
+        },
+        token_recipient: user2.to_string(),
+        finder: None,
+        collection: collection.to_string(),
+    };
+
+    let res: StdResult<SwapResponse> = router
+        .wrap()
+        .query_wasm_smart(infinity_pool.clone(), &swap_msg);
+    assert!(res.is_ok());
+    println!("res is {:?}", res);
+    let swaps = res.unwrap().swaps;
+    let highest_seller_price = spot_price_2 + Uint128::from(100u64).u128();
+    let spot_price_plus_delta = spot_price_2 + 100_u128;
+    let expected_royalty_fee = Uint128::from(spot_price_plus_delta)
+        .checked_multiply_ratio(10_u128, 100_u128)
+        .unwrap()
+        .u128();
+    let expected_network_fee = Uint128::from(spot_price_plus_delta)
+        .checked_multiply_ratio(2_u128, 100_u128)
+        .unwrap()
+        .u128();
+
+    check_nft_sale(
+        highest_seller_price,
+        expected_royalty_fee,
+        expected_network_fee,
+        0,
+        swaps,
+        creator,
+        user2,
+        token_id_2.to_string(),
+    )
+}
+
+#[test]
+fn trading_fee_is_applied_correctly() {
+    let spot_price_1 = 1000_u128;
+    let spot_price_2 = 1200_u128;
+    let trading_fee = 500_u64;
+
+    let vt = standard_minter_template(5000);
+
+    let mut router = vt.router;
+    let collection = vt.collection_response_vec[0].collection.as_ref().unwrap();
+    let user2 = setup_second_bidder_account(&mut router).unwrap();
+    let creator = vt.accts.creator;
+
+    let vts = VendingTemplateSetup {
+        router: &mut router,
+        minter: vt.collection_response_vec[0].minter.as_ref().unwrap(),
+        creator: creator.clone(),
+        user1: vt.accts.bidder,
+        user2: user2.clone(),
+        collection: &collection.clone(),
+    };
+    let swap_pool_configs = vec![
+        SwapPoolSetup {
+            pool_type: PoolType::Trade,
+            spot_price: spot_price_1,
+            finders_fee_bps: None,
+        },
+        SwapPoolSetup {
+            pool_type: PoolType::Trade,
+            spot_price: spot_price_2,
+            finders_fee_bps: None,
+        },
+    ];
+    let swap_results: Vec<Result<SwapPoolResult, anyhow::Error>> =
+        setup_swap_pool(vts, swap_pool_configs, Some(trading_fee));
+
+    let sprs: Vec<Result<SwapPoolResult, anyhow::Error>> = swap_results;
+    let infinity_pool = &sprs[1].as_ref().unwrap().infinity_pool.clone();
+    let mut token_id_1 = 0;
+
+    for spr in sprs {
+        let spr = spr.unwrap();
+        set_pool_active(
+            &mut router,
+            true,
+            spr.pool.clone(),
+            creator.clone(),
+            infinity_pool.clone(),
+        );
+
+        token_id_1 = deposit_nfts(
+            &mut router,
+            spr.user1.clone(),
+            spr.minter.clone(),
+            spr.collection.clone(),
+            spr.infinity_pool.clone(),
+            spr.pool.clone(),
+            spr.creator.clone(),
+        )
+        .token_id_1;
+
+        let _ = deposit_tokens(
+            &mut router,
+            20500_u128,
+            spr.infinity_pool.clone(),
+            spr.pool.clone(),
+            spr.creator.clone(),
+        );
+    }
+    let sale_price = 1000_u128;
+    let swap_msg = get_sim_swap_nfts_for_tokens_msg(
+        collection,
+        token_id_1,
+        sale_price,
+        true,
+        user2.clone(),
+        None,
+    );
+    let query_msg = QueryMsg::PoolQuotesSell {
+        collection: collection.to_string(),
+        query_options: QueryOptions {
+            /// Whether to sort items in ascending or descending order
+            descending: None,
+            /// The key to start the query after
+            start_after: None,
+            // The number of items that will be returned
+            limit: Some(5),
+        },
+    };
+    let res: StdResult<PoolQuoteResponse> =
+        router.wrap().query_wasm_smart(infinity_pool, &query_msg);
+    let expected_pool_quotes = PoolQuoteResponse {
+        pool_quotes: vec![
+            PoolQuote {
+                id: 2,
+                collection: collection.clone(),
+                quote_price: spot_price_2.into(),
+            },
+            PoolQuote {
+                id: 1,
+                collection: collection.clone(),
+                quote_price: spot_price_1.into(),
+            },
+        ],
+    };
+    assert_eq!(res.unwrap(), expected_pool_quotes);
+
+    let res: StdResult<SwapResponse> = router
+        .wrap()
+        .query_wasm_smart(infinity_pool.clone(), &swap_msg);
+    assert!(res.is_ok());
+    let swaps = res.unwrap().swaps;
+    let spot_price_plus_delta = spot_price_2 + 100_u128;
+    let expected_network_fee = Uint128::from(spot_price_plus_delta)
+        .checked_multiply_ratio(5_u128, 100_u128)
+        .unwrap()
+        .u128();
+    let expected_royalty_fee = Uint128::from(spot_price_plus_delta)
+        .checked_multiply_ratio(10_u128, 100_u128)
+        .unwrap()
+        .u128();
+    check_nft_sale(
+        spot_price_plus_delta,
+        expected_royalty_fee,
+        expected_network_fee,
+        0,
+        swaps,
+        creator,
+        user2,
+        token_id_1.to_string(),
+    )
+}
+
+#[test]
+fn royalty_fee_applied_correctly() {
+    let spot_price_1 = 1000_u128;
+    let spot_price_2 = 1200_u128;
+    let vt = _minter_template_30_pct_fee(5000);
+
+    let mut router = vt.router;
+    let collection = vt.collection_response_vec[0].collection.as_ref().unwrap();
+    let user2 = setup_second_bidder_account(&mut router).unwrap();
+    let creator = vt.accts.creator;
+
+    let vts = VendingTemplateSetup {
+        router: &mut router,
+        minter: vt.collection_response_vec[0].minter.as_ref().unwrap(),
+        creator: creator.clone(),
+        user1: vt.accts.bidder,
+        user2: user2.clone(),
+        collection: &collection.clone(),
+    };
+    let swap_pool_configs = vec![
+        SwapPoolSetup {
+            pool_type: PoolType::Trade,
+            spot_price: spot_price_1,
+            finders_fee_bps: None,
+        },
+        SwapPoolSetup {
+            pool_type: PoolType::Trade,
+            spot_price: spot_price_2,
+            finders_fee_bps: None,
+        },
+    ];
+    let swap_results: Vec<Result<SwapPoolResult, anyhow::Error>> =
+        setup_swap_pool(vts, swap_pool_configs, None);
+
+    let sprs: Vec<Result<SwapPoolResult, anyhow::Error>> = swap_results;
+    let infinity_pool = &sprs[1].as_ref().unwrap().infinity_pool.clone();
+    let mut token_id_1 = 0;
+
+    for spr in sprs {
+        let spr = spr.unwrap();
+        set_pool_active(
+            &mut router,
+            true,
+            spr.pool.clone(),
+            creator.clone(),
+            infinity_pool.clone(),
+        );
+
+        token_id_1 = deposit_nfts(
+            &mut router,
+            spr.user1.clone(),
+            spr.minter.clone(),
+            spr.collection.clone(),
+            spr.infinity_pool.clone(),
+            spr.pool.clone(),
+            spr.creator.clone(),
+        )
+        .token_id_1;
+
+        let _ = deposit_tokens(
+            &mut router,
+            20500_u128,
+            spr.infinity_pool.clone(),
+            spr.pool.clone(),
+            spr.creator.clone(),
+        );
+    }
+    let sale_price = 1000_u128;
+    let swap_msg = get_sim_swap_nfts_for_tokens_msg(
+        collection,
+        token_id_1,
+        sale_price,
+        true,
+        user2.clone(),
+        None,
+    );
+    let query_msg = QueryMsg::PoolQuotesSell {
+        collection: collection.to_string(),
+        query_options: QueryOptions {
+            /// Whether to sort items in ascending or descending order
+            descending: None,
+            /// The key to start the query after
+            start_after: None,
+            // The number of items that will be returned
+            limit: Some(5),
+        },
+    };
+    let res: StdResult<PoolQuoteResponse> =
+        router.wrap().query_wasm_smart(infinity_pool, &query_msg);
+    let expected_pool_quotes = PoolQuoteResponse {
+        pool_quotes: vec![
+            PoolQuote {
+                id: 2,
+                collection: collection.clone(),
+                quote_price: spot_price_2.into(),
+            },
+            PoolQuote {
+                id: 1,
+                collection: collection.clone(),
+                quote_price: spot_price_1.into(),
+            },
+        ],
+    };
+    assert_eq!(res.unwrap(), expected_pool_quotes);
+
+    let res: StdResult<SwapResponse> = router
+        .wrap()
+        .query_wasm_smart(infinity_pool.clone(), &swap_msg);
+    assert!(res.is_ok());
+    let swaps = res.unwrap().swaps;
+    let spot_price_plus_delta = spot_price_2 + 100_u128;
+    let expected_network_fee = Uint128::from(spot_price_plus_delta)
+        .checked_multiply_ratio(2_u128, 100_u128)
+        .unwrap()
+        .u128();
+    let expected_royalty_fee = Uint128::from(spot_price_plus_delta)
+        .checked_multiply_ratio(30_u128, 100_u128)
+        .unwrap()
+        .u128();
+    check_nft_sale(
+        spot_price_plus_delta,
+        expected_royalty_fee,
+        expected_network_fee,
+        0,
+        swaps,
+        creator,
+        user2,
+        token_id_1.to_string(),
+    )
+}
+
+#[test]
+fn finders_fee_is_applied_correctly() {
+    let spot_price_1 = 1000_u128;
+    let spot_price_2 = 1200_u128;
+    let finders_fee_bps = 2_u128;
+    let vt = standard_minter_template(5000);
+
+    let mut router = vt.router;
+    let collection = vt.collection_response_vec[0].collection.as_ref().unwrap();
+    let user2 = setup_second_bidder_account(&mut router).unwrap();
+    let creator = vt.accts.creator;
+
+    let vts = VendingTemplateSetup {
+        router: &mut router,
+        minter: vt.collection_response_vec[0].minter.as_ref().unwrap(),
+        creator: creator.clone(),
+        user1: vt.accts.bidder,
+        user2: user2.clone(),
+        collection: &collection.clone(),
+    };
+    let swap_pool_configs = vec![
+        SwapPoolSetup {
+            pool_type: PoolType::Trade,
+            spot_price: spot_price_1,
+            finders_fee_bps: Some(finders_fee_bps.try_into().unwrap()),
+        },
+        SwapPoolSetup {
+            pool_type: PoolType::Trade,
+            spot_price: spot_price_2,
+            finders_fee_bps: Some(finders_fee_bps.try_into().unwrap()),
+        },
+    ];
+    let swap_results: Vec<Result<SwapPoolResult, anyhow::Error>> =
+        setup_swap_pool(vts, swap_pool_configs, None);
+
+    let sprs: Vec<Result<SwapPoolResult, anyhow::Error>> = swap_results;
+    let infinity_pool = &sprs[1].as_ref().unwrap().infinity_pool.clone();
+    let mut token_id_1 = 0;
+
+    for spr in sprs {
+        let spr = spr.unwrap();
+        set_pool_active(
+            &mut router,
+            true,
+            spr.pool.clone(),
+            creator.clone(),
+            infinity_pool.clone(),
+        );
+
+        let tokens = deposit_nfts(
+            &mut router,
+            spr.user1.clone(),
+            spr.minter.clone(),
+            spr.collection.clone(),
+            spr.infinity_pool.clone(),
+            spr.pool.clone(),
+            spr.creator.clone(),
+        );
+        token_id_1 = tokens.token_id_1;
+
+        let _ = deposit_tokens(
+            &mut router,
+            20500_u128,
+            spr.infinity_pool.clone(),
+            spr.pool.clone(),
+            spr.creator.clone(),
+        );
+    }
+    let sale_price = 1000_u128;
+    let swap_msg = get_sim_swap_nfts_for_tokens_msg(
+        collection,
+        token_id_1,
+        sale_price,
+        true,
+        user2.clone(),
+        Some(user2.to_string()),
+    );
+    let query_msg = QueryMsg::PoolQuotesSell {
+        collection: collection.to_string(),
+        query_options: QueryOptions {
+            /// Whether to sort items in ascending or descending order
+            descending: None,
+            /// The key to start the query after
+            start_after: None,
+            // The number of items that will be returned
+            limit: Some(5),
+        },
+    };
+    let res: StdResult<PoolQuoteResponse> =
+        router.wrap().query_wasm_smart(infinity_pool, &query_msg);
+    let expected_pool_quotes = PoolQuoteResponse {
+        pool_quotes: vec![
+            PoolQuote {
+                id: 2,
+                collection: collection.clone(),
+                quote_price: spot_price_2.into(),
+            },
+            PoolQuote {
+                id: 1,
+                collection: collection.clone(),
+                quote_price: spot_price_1.into(),
+            },
+        ],
+    };
+    assert_eq!(res.unwrap(), expected_pool_quotes);
+
+    let res: StdResult<SwapResponse> = router
+        .wrap()
+        .query_wasm_smart(infinity_pool.clone(), &swap_msg);
+    assert!(res.is_ok());
+    let swaps = res.unwrap().swaps;
+    let spot_price_plus_delta = spot_price_2 + 100_u128;
+    let expected_network_fee = Uint128::from(spot_price_plus_delta)
+        .checked_multiply_ratio(2_u128, 100_u128)
+        .unwrap()
+        .u128();
+    let expected_royalty_fee = Uint128::from(spot_price_plus_delta)
+        .checked_multiply_ratio(10_u128, 100_u128)
+        .unwrap()
+        .u128();
+    let expected_finders_fee = Uint128::from(spot_price_plus_delta)
+        .checked_multiply_ratio(finders_fee_bps, Uint128::new(100).u128())
+        .unwrap();
+
+    check_nft_sale(
+        spot_price_plus_delta,
+        expected_royalty_fee,
+        expected_network_fee,
+        expected_finders_fee.u128(),
+        swaps,
+        creator,
+        user2,
+        token_id_1.to_string(),
+    )
 }

--- a/contracts/infinity-pool/src/testing/tests/sim_tests/sim_swap_nfts_for_tokens.rs
+++ b/contracts/infinity-pool/src/testing/tests/sim_tests/sim_swap_nfts_for_tokens.rs
@@ -4,7 +4,8 @@ use crate::testing::setup::setup_accounts::setup_second_bidder_account;
 use crate::testing::setup::templates::{_minter_template_30_pct_fee, standard_minter_template};
 use crate::testing::tests::sim_tests::helpers::{
     check_nft_sale, deposit_nfts, deposit_tokens, get_sim_swap_nfts_for_tokens_msg,
-    set_pool_active, setup_swap_pool, SwapPoolResult, SwapPoolSetup, VendingTemplateSetup,
+    set_pool_active, setup_swap_pool, NftSaleCheckParams, SwapPoolResult, SwapPoolSetup,
+    VendingTemplateSetup,
 };
 use crate::testing::tests::sim_tests::sim_swap_nfts_for_tokens::QueryMsg::SimSwapNftsForTokens;
 use cosmwasm_std::StdError::GenericErr;
@@ -13,6 +14,8 @@ use cosmwasm_std::Uint128;
 use cosmwasm_std::{Addr, Timestamp};
 use sg_std::GENESIS_MINT_START_TIME;
 use std::vec;
+
+use crate::testing::tests::sim_tests::helpers::ASSET_ACCOUNT;
 
 #[test]
 fn cant_swap_two_inactive_pools() {
@@ -231,16 +234,19 @@ fn can_swap_two_active_pools() {
         .unwrap()
         .u128();
 
-    check_nft_sale(
-        highest_seller_price,
-        expected_royalty_fee,
+    let nft_sale_check_params = NftSaleCheckParams {
+        expected_spot_price: highest_seller_price,
+        expected_royalty_price: expected_royalty_fee,
         expected_network_fee,
-        0,
+        expected_finders_fee: 0,
         swaps,
         creator,
-        user2,
-        token_id_1.to_string(),
-    )
+        expected_seller: user2.clone(),
+        token_id: token_id_1.to_string(),
+        expected_nft_payer: Addr::unchecked(ASSET_ACCOUNT),
+        expected_finder: user2,
+    };
+    check_nft_sale(nft_sale_check_params);
 }
 
 #[test]
@@ -610,7 +616,6 @@ fn robust_query_does_not_revert_whole_tx_on_error() {
         .wrap()
         .query_wasm_smart(infinity_pool.clone(), &swap_msg);
     assert!(res.is_ok());
-    println!("res is {:?}", res);
     let swaps = res.unwrap().swaps;
     let highest_seller_price = spot_price_2 + Uint128::from(100u64).u128();
     let spot_price_plus_delta = spot_price_2 + 100_u128;
@@ -623,16 +628,19 @@ fn robust_query_does_not_revert_whole_tx_on_error() {
         .unwrap()
         .u128();
 
-    check_nft_sale(
-        highest_seller_price,
-        expected_royalty_fee,
+    let nft_sale_check_params = NftSaleCheckParams {
+        expected_spot_price: highest_seller_price,
+        expected_royalty_price: expected_royalty_fee,
         expected_network_fee,
-        0,
+        expected_finders_fee: 0,
         swaps,
         creator,
-        user2,
-        token_id_2.to_string(),
-    )
+        expected_seller: user2.clone(),
+        token_id: token_id_2.to_string(),
+        expected_nft_payer: Addr::unchecked(ASSET_ACCOUNT),
+        expected_finder: user2,
+    };
+    check_nft_sale(nft_sale_check_params)
 }
 
 #[test]
@@ -756,16 +764,21 @@ fn trading_fee_is_applied_correctly() {
         .checked_multiply_ratio(10_u128, 100_u128)
         .unwrap()
         .u128();
-    check_nft_sale(
-        spot_price_plus_delta,
-        expected_royalty_fee,
+
+    let nft_sale_check_params = NftSaleCheckParams {
+        expected_spot_price: spot_price_plus_delta,
+        expected_royalty_price: expected_royalty_fee,
         expected_network_fee,
-        0,
+        expected_finders_fee: 0,
         swaps,
         creator,
-        user2,
-        token_id_1.to_string(),
-    )
+        expected_seller: user2.clone(),
+        token_id: token_id_1.to_string(),
+        expected_nft_payer: Addr::unchecked(ASSET_ACCOUNT),
+        expected_finder: user2,
+    };
+
+    check_nft_sale(nft_sale_check_params);
 }
 
 #[test]
@@ -887,16 +900,21 @@ fn royalty_fee_applied_correctly() {
         .checked_multiply_ratio(30_u128, 100_u128)
         .unwrap()
         .u128();
-    check_nft_sale(
-        spot_price_plus_delta,
-        expected_royalty_fee,
+
+    let nft_sale_check_params = NftSaleCheckParams {
+        expected_spot_price: spot_price_plus_delta,
+        expected_royalty_price: expected_royalty_fee,
         expected_network_fee,
-        0,
+        expected_finders_fee: 0,
         swaps,
         creator,
-        user2,
-        token_id_1.to_string(),
-    )
+        expected_seller: user2.clone(),
+        token_id: token_id_1.to_string(),
+        expected_nft_payer: Addr::unchecked(ASSET_ACCOUNT),
+        expected_finder: user2,
+    };
+
+    check_nft_sale(nft_sale_check_params);
 }
 
 #[test]
@@ -1023,14 +1041,18 @@ fn finders_fee_is_applied_correctly() {
         .checked_multiply_ratio(finders_fee_bps, Uint128::new(100).u128())
         .unwrap();
 
-    check_nft_sale(
-        spot_price_plus_delta,
-        expected_royalty_fee,
+    let nft_sale_check_params = NftSaleCheckParams {
+        expected_spot_price: spot_price_plus_delta,
+        expected_royalty_price: expected_royalty_fee,
         expected_network_fee,
-        expected_finders_fee.u128(),
+        expected_finders_fee: expected_finders_fee.u128(),
         swaps,
         creator,
-        user2,
-        token_id_1.to_string(),
-    )
+        expected_seller: user2.clone(),
+        token_id: token_id_1.to_string(),
+        expected_nft_payer: Addr::unchecked(ASSET_ACCOUNT),
+        expected_finder: user2,
+    };
+
+    check_nft_sale(nft_sale_check_params);
 }


### PR DESCRIPTION
Finishing the rest of the test cases for SimSwapNftsForTokens. Following test cases are covered: 

- assert error thrown when pool is not active
- assert error when pool is not of type `Token` or `Trade`
- assert error thrown when pool has insufficient tokens
- assert error thrown when sale price is below the min expected
- assert robust query does not revert whole tx on error
- assert robust query does revert whole tx on error
- fees
    - assert marketplace trading fee is calculated correctly
    - assert royalties are calculated correctly
    - assert finders fee is calculated correctly
    - assert seller payment is calculated correctly